### PR TITLE
Image Picker package updated to 

### DIFF
--- a/ScanbotBarcodeSDKExample/BarcodeSDK.MAUI.Example/BarcodeSDK.MAUI.Example.csproj
+++ b/ScanbotBarcodeSDKExample/BarcodeSDK.MAUI.Example/BarcodeSDK.MAUI.Example.csproj
@@ -100,7 +100,7 @@
     <!-- ===================== Android Project References =====================  -->
     <ItemGroup>
         <PackageReference Include="ScanbotBarcodeSDK.MAUI" Version="3.6.0" />
-        <PackageReference Include="Scanbot.Xamarin.Forms.ImagePicker" Version="0.0.3-alpha.1" />
+        <PackageReference Include="Scanbot.Xamarin.Forms.ImagePicker" Version="0.0.3-alpha.2" />
     </ItemGroup>
     <ItemGroup>
         <None Remove="Models\" />

--- a/ScanbotBarcodeSDKExample/BarcodeSDK.NET.Droid/BarcodeSDK.NET.Droid.csproj
+++ b/ScanbotBarcodeSDKExample/BarcodeSDK.NET.Droid/BarcodeSDK.NET.Droid.csproj
@@ -10,7 +10,7 @@
         <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     </PropertyGroup>
     <ItemGroup>
-         <PackageReference Include="Scanbot.Xamarin.ImagePicker" Version="0.0.3-alpha.1" />
+         <PackageReference Include="Scanbot.Xamarin.ImagePicker" Version="0.0.3-alpha.2" />
         <PackageReference Include="ScanbotBarcodeSDK.NET" Version="3.6.0" />
     </ItemGroup>
 </Project>

--- a/ScanbotBarcodeSDKExample/BarcodeSDK.NET.iOS/BarcodeSDK.NET.iOS.csproj
+++ b/ScanbotBarcodeSDKExample/BarcodeSDK.NET.iOS/BarcodeSDK.NET.iOS.csproj
@@ -32,7 +32,7 @@
         <CreatePackage>false</CreatePackage>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Scanbot.Xamarin.ImagePicker" Version="0.0.3-alpha.1" />
+        <PackageReference Include="Scanbot.Xamarin.ImagePicker" Version="0.0.3-alpha.2" />
         <PackageReference Include="ScanbotBarcodeSDK.NET" Version="3.6.0" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
- [x] Fixed the crash for iOS 14.x version in Image Picker Library. Updated the Image Picker nuget package to v0.0.3-alpha.2