### PR TITLE
[EPIC-6017] NET BS 7.0: Empty Barcodes check

### DIFF
--- a/BarcodeSDK.NET.iOS.Example/Controllers/MainViewController.RtuUi.cs
+++ b/BarcodeSDK.NET.iOS.Example/Controllers/MainViewController.RtuUi.cs
@@ -123,6 +123,9 @@ public partial class MainViewController
 
     private void ShowBarcodeResults(SBSDKUI2BarcodeScannerUIItem[] items)
     {
+        if (items == null || items.Length == 0)
+            return;
+        
         var viewController = new ScanResultListController(items);
         NavigationController?.PushViewController(viewController, true);
     }


### PR DESCRIPTION
- iOS: Updated the null and empty check for Barcode RTU results